### PR TITLE
Master

### DIFF
--- a/calendar-v2-proxied.xml
+++ b/calendar-v2-proxied.xml
@@ -135,6 +135,14 @@
     __UP_body-style__;
     font-size: 80% !important;
   }
+  
+  #lastupdate {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    font-size: 7px;
+    color: #ffffff88;
+  }
 </style>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js" type="text/javascript"></script>
@@ -168,6 +176,7 @@
 
 <script type="text/javascript">
 
+  var lastUpdate;
   var prefs = new gadgets.Prefs();
   
   function load() {
@@ -232,35 +241,40 @@
     }
     
 	gadgets.io.makeRequest(url, function(result) {
-      if (result.rc === 200) {
-		var response = result.data;
+    if (result.rc === 200) {
+
+      $("#lastupdate").text('Updated: ' + moment().format('YYYY-MM-DDTHH:mm:ssZ'));
+
+		  var response = result.data;
 		
-		if (response.timeZone) {
-        //moment.tz.setDefault(response.timeZone);
-		}
-		for (var i = 0; i < response.items.length; i++) {
-			if (prefs.getString("displayFormat") == "table") {
-			  formatTable(response.items[i]);
-			} else {
-			  formatDiv(response.items[i]);
-			}
-		}  
-		if (prefs.getString("scrollSpeed") != "none") {
-			$("#data").autoScroll({
-			  speed: prefs.getString("scrollSpeed"),
-			  by: prefs.getString("scrollBy")
-			}).on("done", function() {
-			  $("#data").data("plugin_autoScroll").play();
-			});
-			$("#data").data("plugin_autoScroll").play();
-		}
+      if (response.timeZone) {
+          //moment.tz.setDefault(response.timeZone);
+      }
+      for (var i = 0; i < response.items.length; i++) {
+        if (prefs.getString("displayFormat") == "table") {
+          formatTable(response.items[i]);
+        } else {
+          formatDiv(response.items[i]);
+        }
+      }  
+      if (prefs.getString("scrollSpeed") != "none") {
+        $("#data").autoScroll({
+          speed: prefs.getString("scrollSpeed"),
+          by: prefs.getString("scrollBy")
+        }).on("done", function() {
+          $("#data").data("plugin_autoScroll").play();
+        });
+        $("#data").data("plugin_autoScroll").play();
+      }
 	  } else {
-		console.log(url);
-		console.log('get calendar failed: ' + result.errors[0]);
-	  
-		setTimeout(function() {
-		  update();
-		}, 120000);
+      console.log(url);
+      console.log('get calendar failed: ' + result.errors[0]);
+      
+      $("#lastupdate").text('Update failed: ' + moment().format('YYYY-MM-DDTHH:mm:ssZ'));
+
+      setTimeout(function() {
+        update();
+      }, 120000);
 	  }
     },
     {

--- a/calendar-v2.xml
+++ b/calendar-v2.xml
@@ -77,7 +77,11 @@
   {
     __UP_body-style__;
     width: __UP_rdW__px;
+    height: __UP_rdH__px;
     text-align: center;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   table, div#events

--- a/calendar-v2.xml
+++ b/calendar-v2.xml
@@ -30,6 +30,7 @@
     <EnumValue value="continuous" display_value="Continuous" />
     <EnumValue value="page" display_value="Page" />
   </UserPref>
+  <UserPref name="noEventsMessage" display_name="No Events Message" datatype="string" />
   <UserPref name="rdW" display_name="Width" required="true" default_value="280" datatype="hidden" />
   <UserPref name="rdH" display_name="Height" required="true" default_value="190" datatype="hidden" />
   <UserPref name="ForeColor" datatype="hidden" />
@@ -70,6 +71,13 @@
   {
     color: #__UP_ForeColor__;
     width: __UP_rdW__px;
+  }
+
+  #noEventsMessage
+  {
+    __UP_body-style__;
+    width: __UP_rdW__px;
+    text-align: center;
   }
 
   table, div#events
@@ -164,6 +172,9 @@
       </tbody>
     </table>
   </div>
+  <div id="noEventsMessage" style="display:none;">
+    <h2 id="errormsg">__UP_noEventsMessage__</h2>
+  </div>
 </div>
 
 <script type="text/javascript">
@@ -240,6 +251,14 @@
       if (response.timeZone) {
         //moment.tz.setDefault(response.timeZone);
       }
+
+      if (response.items.length == 0) {
+        $("#noEventsMessage").show();
+        return;
+      } else {
+        $("#noEventsMessage").hide();
+      }
+      
       for (var i = 0; i < response.items.length; i++) {
         if (prefs.getString("displayFormat") == "table") {
           formatTable(response.items[i]);

--- a/calendar-v2.xml
+++ b/calendar-v2.xml
@@ -173,7 +173,7 @@
     </table>
   </div>
   <div id="noEventsMessage" style="display:none;">
-    <h2 id="errormsg">__UP_noEventsMessage__</h2>
+    __UP_noEventsMessage__
   </div>
 </div>
 
@@ -258,7 +258,7 @@
       } else {
         $("#noEventsMessage").hide();
       }
-      
+
       for (var i = 0; i < response.items.length; i++) {
         if (prefs.getString("displayFormat") == "table") {
           formatTable(response.items[i]);


### PR DESCRIPTION
This pull request includes several enhancements to the `calendar-v2-proxied.xml` and `calendar-v2.xml` files, focusing on adding a last update timestamp and a no events message. 

Enhancements to `calendar-v2-proxied.xml`:

* Added a `#lastupdate` element to display the last update timestamp in the bottom-right corner. (`calendar-v2-proxied.xml`, [calendar-v2-proxied.xmlR138-R145](diffhunk://#diff-80cb4bece368b77877feac9b23497fdb96c99b515d3de49cdb08d437b2152ea4R138-R145))
* Introduced a `lastUpdate` variable and updated the `#lastupdate` element with the current timestamp upon successful data retrieval. (`calendar-v2-proxied.xml`, [[1]](diffhunk://#diff-80cb4bece368b77877feac9b23497fdb96c99b515d3de49cdb08d437b2152ea4R179) [[2]](diffhunk://#diff-80cb4bece368b77877feac9b23497fdb96c99b515d3de49cdb08d437b2152ea4R245-R247)
* Updated the `#lastupdate` element with an error message and timestamp if data retrieval fails. (`calendar-v2-proxied.xml`, [calendar-v2-proxied.xmlR273-R274](diffhunk://#diff-80cb4bece368b77877feac9b23497fdb96c99b515d3de49cdb08d437b2152ea4R273-R274))

Enhancements to `calendar-v2.xml`:

* Added a new user preference for a no events message (`noEventsMessage`). (`calendar-v2.xml`, [calendar-v2.xmlR33](diffhunk://#diff-50f3e66af929859ea82d3c71e2a2b87173854181bfb3bce521778d0fb54479e3R33))
* Introduced a `#noEventsMessage` element to display a message when there are no events, and updated the script to show or hide this element based on the response. (`calendar-v2.xml`, [[1]](diffhunk://#diff-50f3e66af929859ea82d3c71e2a2b87173854181bfb3bce521778d0fb54479e3R76-R86) [[2]](diffhunk://#diff-50f3e66af929859ea82d3c71e2a2b87173854181bfb3bce521778d0fb54479e3R179-R181) [[3]](diffhunk://#diff-50f3e66af929859ea82d3c71e2a2b87173854181bfb3bce521778d0fb54479e3R258-R265)