### PR TITLE
Update meeting-room.xml

### DIFF
--- a/meeting-room.xml
+++ b/meeting-room.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <Module>
-<ModulePrefs title="RevelDigital Meeting Room Gadget" title_url="https://support.reveldigital.com/hc/en-us/articles/360002538071-Meeting-room-gadget" description="Displays meeting room availability" author="RevelDigital" background="transparent">
+<ModulePrefs title="Meeting Room Gadget" title_url="https://support.reveldigital.com/hc/en-us/articles/360002538071-Meeting-Room-Gadget" description="Displays meeting room availability" author="RevelDigital" background="transparent">
   <Require feature="reveldigital" />
   <Require feature="jquery" />
   <Require feature="webfont" />


### PR DESCRIPTION
title & url update
This pull request includes a minor update to the `meeting-room.xml` file. The change modifies the `title` attribute in the `<ModulePrefs>` tag to standardize the title format.

* [`meeting-room.xml`](diffhunk://#diff-6406ed860a2808b60ffff9cfbe6c3e796a14edb16c1cd3ad2d1ca962e75d4d88L3-R3): Updated the `title` attribute in `<ModulePrefs>` from "RevelDigital Meeting Room Gadget" to "Meeting Room Gadget" for consistency and clarity.