### PR TITLE
Switch weather gadgets to proxy API

### DIFF
--- a/weather-flip.xml
+++ b/weather-flip.xml
@@ -256,171 +256,41 @@
   var titles = {};
   var flipTimer;
   
-  var conditionMap_aeris = {
-    "am_pcloudyr.png": "40d",
-    "am_showers.png": "40d",
-    "am_showshowers.png": "46d",
-    "am_tstorm.png": "4d",
-    "blizzard.png": "46d",
-    "blizzardn.png": "46n",
-    "blowingsnow.png": "42d",
-    "blowingsnown.png": "42n",
-    "chancetstorm.png": "38d",
-    "chancetstormn.png": "38n",
-    "clear.png": "32d",
-    "clearn.png": "32n",
-    "clearw.png": "32d",
-    "clearwn.png": "32n",
-    "cloudy.png": "26d",
-    "cloudyn.png": "26n",
-    "cloudyw.png": "26d",
-    "cloudywn.png": "26n",
-    "drizzle.png": "9d",
-    "drizzlef.png": "9d",
-    "drizzlen.png": "9n",
-    "dust.png": "19d",
-    "fair.png": "33d",
-    "fairn.png": "33n",
-    "fairw.png": "33d",
-    "fairwn.png": "33n",
-    "fdrizzle.png": "8d",
-    "fdrizzlen.png": "8n",
-    "flurries.png": "13d",
-    "flurriesn.png": "13n",
-    "flurriesw.png": "13d",
-    "flurrieswn.png": "13n",
-    "fog.png": "20d",
-    "fogn.png": "20n",
-    "freezingrain.png": "10d",
-    "freezingrainn.png": "10n",
-    "hazy.png": "21d",
-    "hazyn.png": "21n",
-    "mcloudy.png": "27d",
-    "mcloudyn.png": "27n",
-    "mcloudyr.png": "27d",
-    "mcloudyrn.png": "27n",
-    "mcloudyrw.png": "27d",
-    "mcloudyrwn.png": "27n",
-    "mcloudys.png": "27d",
-    "mcloudysfn.png": "27n",
-    "mcloudysfw.png": "27d",
-    "mcloudysfwn.png": "27n",
-    "mcloudysn.png": "27d",
-    "mcloudysw.png": "27d",
-    "mcloudyswn.png": "27n",
-    "mcloudyt.png": "27d",
-    "mcloudytn.png": "27n",
-    "mcloudytw.png": "27d",
-    "mcloudytwn.png": "27n",
-    "mcloudyw.png": "27d",
-    "mcloudywn.png": "27n",
-    "na.png": "",
-    "pcloudy.png": "29d",
-    "pcloudyn.png": "29n",
-    "pcloudyr.png": "29d",
-    "pcloudyrn.png": "29n",
-    "pcloudyrw.png": "29d",
-    "pcloudyrwn.png": "29n",
-    "pcloudys.png": "29d",
-    "pcloudysf.png": "29d",
-    "pcloudysfn.png": "29n",
-    "pcloudysfw.png": "29d",
-    "pcloudysfwn.png": "29n",
-    "pcloudysn.png": "29n",
-    "pcloudysw.png": "29d",
-    "pcloudyswn.png": "29n",
-    "pcloudyt.png": "29d",
-    "pcloudytn.png": "29n",
-    "pcloudytw.png": "29d",
-    "pcloudytwn.png": "29n",
-    "pcloudyw.png": "29d",
-    "pcloudywn.png": "29n",
-    "pm_pcloudy.png": "29d",
-    "pm_pcloudyr.png": "29d",
-    "pm_showers.png": "12d",
-    "pm_snowshowers.png": "46d",
-    "pm_tstorm.png": "4d",
-    "rain.png": "11d",
-    "rainandsnow.png": "5d",
-    "rainandsnown.png": "5n",
-    "rainn.png": "11n",
-    "raintosnow.png": "5d",
-    "raintosnown.png": "5n",
-    "rainw.png": "11d",
-    "showers.png": "11d",
-    "showersn.png": "11n",
-    "showersw.png": "11d",
-    "sleet.png": "18d",
-    "sleetn.png": "18n",
-    "sleetsnow.png": "7d",
-    "smoke.png": "22d",
-    "smoken.png": "22n",
-    "snow.png": "16d",
-    "snown.png": "16n",
-    "snowshowers.png": "46d",	
-    "snowshowersn.png": "46n",
-    "snowshowersw.png": "46d",
-    "snowshowerswn.png": "46n",
-    "snowtorain.png": "5d",
-    "snowtorainn.png": "5n",
-    "snoww.png": "16d",
-    "snowwn.png": "16n",
-    "sunny.png": "32d",
-    "sunnyn.png": "32n",
-    "sunnyw.png": "32d",
-    "sunnywn.png": "32n",
-    "tstorm.png": "4d",
-    "tstormn.png": "4n",
-    "tstormsw.png": "4d",
-    "tstormswn.png": "4n",
-    "tstormw.png": "4d",
-    "tstormwn.png": "4n",
-    "wind.png": "24d",
-    "wintrymix.png": "7d",
-    "wintrymixn.png": "7n"
-  };
-  
+  // Icon per weather condition returned by the proxy, as [day, night] codes.
   var conditionMap = {
-    "chanceflurries": "42d",
-    "chancerain": "40d",
-    "chancesleet": "18d",
-    "chancesnow": "42d",
-    "chancetstorms": "38d",
-    "clear": "32d",
-    "cloudy": "26d",
-    "flurries": "13d",
-    "fog": "20d",
-    "hazy": "21d",
-    "mostlycloudy": "28d",
-    "mostlysunny": "29d",
-    "partlycloudy": "30d",
-    "partlysunny": "28d",
-    "sleet": "18d",
-    "rain": "11d",
-    "snow": "16d",
-    "sunny": "32d",
-    "tstorms": "4d",
-    "nt_chanceflurries": "42n",
-    "nt_chancerain": "40n",
-    "nt_chancesleet": "18n",
-    "nt_chancesnow": "42n",
-    "nt_chancetstorms": "38n",
-    "nt_clear": "32n",
-    "nt_cloudy": "26n",
-    "nt_flurries": "13n",
-    "nt_fog": "20n",
-    "nt_hazy": "21n",
-    "nt_mostlycloudy": "28n",
-    "nt_mostlysunny": "29n",
-    "nt_partlycloudy": "30n",
-    "nt_partlysunny": "28n",
-    "nt_sleet": "18n",
-    "nt_rain": "11n",
-    "nt_snow": "16n",
-    "nt_sunny": "32n",
-    "nt_tstorms": "4n"
+    "clear": ["32d", "32n"],
+    "partly-cloudy": ["29d", "29n"],
+    "cloudy": ["26d", "26n"],
+    "fog": ["20d", "20n"],
+    "drizzle": ["9d", "9n"],
+    "freezing-rain": ["10d", "10n"],
+    "rain": ["11d", "11n"],
+    "showers": ["11d", "11n"],
+    "snow": ["16d", "16n"],
+    "thunderstorm": ["4d", "4n"],
+    "unknown": ["32d", "32n"]
   };
-  
+
+  function getIconCode(condition, isDay) {
+    var pair = conditionMap[condition] || conditionMap["unknown"];
+    return isDay === false ? pair[1] : pair[0];
+  }
+
+  var WEATHER_API = 'https://proxy-svc.reveldigital.app/weather';
+
+  // The proxy is always asked for US units and Celsius is derived here, so devices on
+  // either unit preference share a single cached upstream response.
+  function toC(f) {
+    return f == null ? null : (f - 32) * 5 / 9;
+  }
+
+  function resolveLocation(location) {
+    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
+      return "Fargo, ND";
+    }
+    return location;
+  }
+
   function load() {
     
     WebFont.load({
@@ -463,24 +333,28 @@
   }
   
   function getWeather(location) {
-  
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    var api = 'https://api.aerisapi.com/observations/' + encodeURIComponent(location) + '?client_id=hUqX7OlM6GSNFSm9wyhPF&client_secret=dkklytjvrU9sVSfMsNwF6rTiFk8VObvUkwlhPgrW';
+
+    var place = resolveLocation(location);
     $.ajax({
       type: 'GET',
-      url: api,
+      url: WEATHER_API,
+      data: { q: place, units: 'us', days: 1 },
       dataType: 'json',
       success: function(data) {
-        if (data.success === false) {
+        if (!data || !data.current) {
           return;
         }
-        var item = data.response.ob;
+        var current = data.current;
 
-        item.location = location;
-        items.push(item);
-        
+        items.push({
+          location: place,
+          icon: current.weather.icon,
+          isDay: current.isDay,
+          weather: current.weather.label,
+          tempF: current.temp,
+          tempC: toC(current.temp)
+        });
+
         if (items.length == 1) {
           flip();
         }
@@ -500,7 +374,7 @@
     
     $('div.location', panel).text(item.location);
     $('div.condition', panel).text(item.weather);
-    $('img.icon', panel).attr("src", "https://s.yimg.com/zz/combo?a/i/us/nws/weather/gr/" + conditionMap_aeris[item.icon] + ".png");
+    $('img.icon', panel).attr("src", "https://s.yimg.com/zz/combo?a/i/us/nws/weather/gr/" + getIconCode(item.icon, item.isDay) + ".png");
     
     if (prefs.getString("Units") == "f") {
       $('div.temp', panel).text(parseInt(item.tempF) + "\u00B0");

--- a/weather-horizontal.xml
+++ b/weather-horizontal.xml
@@ -257,173 +257,65 @@
   var search = prefs.getString("Location");
   var unit = prefs.getString("Units");    
     
-  var conditionMap_aeris = {
-    "am_pcloudyr.png": "40d",
-    "am_showers.png": "40d",
-    "am_showshowers.png": "46d",
-    "am_tstorm.png": "4d",
-    "blizzard.png": "46d",
-    "blizzardn.png": "46n",
-    "blowingsnow.png": "42d",
-    "blowingsnown.png": "42n",
-    "chancetstorm.png": "38d",
-    "chancetstormn.png": "38n",
-    "clear.png": "32d",
-    "clearn.png": "32n",
-    "clearw.png": "32d",
-    "clearwn.png": "32n",
-    "cloudy.png": "26d",
-    "cloudyn.png": "26n",
-    "cloudyw.png": "26d",
-    "cloudywn.png": "26n",
-    "drizzle.png": "9d",
-    "drizzlef.png": "9d",
-    "drizzlen.png": "9n",
-    "dust.png": "19d",
-    "fair.png": "33d",
-    "fairn.png": "33n",
-    "fairw.png": "33d",
-    "fairwn.png": "33n",
-    "fdrizzle.png": "8d",
-    "fdrizzlen.png": "8n",
-    "flurries.png": "13d",
-    "flurriesn.png": "13n",
-    "flurriesw.png": "13d",
-    "flurrieswn.png": "13n",
-    "fog.png": "20d",
-    "fogn.png": "20n",
-    "freezingrain.png": "10d",
-    "freezingrainn.png": "10n",
-    "hazy.png": "21d",
-    "hazyn.png": "21n",
-    "mcloudy.png": "27d",
-    "mcloudyn.png": "27n",
-    "mcloudyr.png": "27d",
-    "mcloudyrn.png": "27n",
-    "mcloudyrw.png": "27d",
-    "mcloudyrwn.png": "27n",
-    "mcloudys.png": "27d",
-    "mcloudysfn.png": "27n",
-    "mcloudysfw.png": "27d",
-    "mcloudysfwn.png": "27n",
-    "mcloudysn.png": "27d",
-    "mcloudysw.png": "27d",
-    "mcloudyswn.png": "27n",
-    "mcloudyt.png": "27d",
-    "mcloudytn.png": "27n",
-    "mcloudytw.png": "27d",
-    "mcloudytwn.png": "27n",
-    "mcloudyw.png": "27d",
-    "mcloudywn.png": "27n",
-    "na.png": "",
-    "pcloudy.png": "29d",
-    "pcloudyn.png": "29n",
-    "pcloudyr.png": "29d",
-    "pcloudyrn.png": "29n",
-    "pcloudyrw.png": "29d",
-    "pcloudyrwn.png": "29n",
-    "pcloudys.png": "29d",
-    "pcloudysf.png": "29d",
-    "pcloudysfn.png": "29n",
-    "pcloudysfw.png": "29d",
-    "pcloudysfwn.png": "29n",
-    "pcloudysn.png": "29n",
-    "pcloudysw.png": "29d",
-    "pcloudyswn.png": "29n",
-    "pcloudyt.png": "29d",
-    "pcloudytn.png": "29n",
-    "pcloudytw.png": "29d",
-    "pcloudytwn.png": "29n",
-    "pcloudyw.png": "29d",
-    "pcloudywn.png": "29n",
-    "pm_pcloudy.png": "29d",
-    "pm_pcloudyr.png": "29d",
-    "pm_showers.png": "12d",
-    "pm_snowshowers.png": "46d",
-    "pm_tstorm.png": "4d",
-    "rain.png": "11d",
-    "rainandsnow.png": "5d",
-    "rainandsnown.png": "5n",
-    "rainn.png": "11n",
-    "raintosnow.png": "5d",
-    "raintosnown.png": "5n",
-    "rainw.png": "11d",
-    "showers.png": "11d",
-    "showersn.png": "11n",
-    "showersw.png": "11d",
-    "sleet.png": "18d",
-    "sleetn.png": "18n",
-    "sleetsnow.png": "7d",
-    "smoke.png": "22d",
-    "smoken.png": "22n",
-    "snow.png": "16d",
-    "snown.png": "16n",
-    "snowshowers.png": "46d",	
-    "snowshowersn.png": "46n",
-    "snowshowersw.png": "46d",
-    "snowshowerswn.png": "46n",
-    "snowtorain.png": "5d",
-    "snowtorainn.png": "5n",
-    "snoww.png": "16d",
-    "snowwn.png": "16n",
-    "sunny.png": "32d",
-    "sunnyn.png": "32n",
-    "sunnyw.png": "32d",
-    "sunnywn.png": "32n",
-    "tstorm.png": "4d",
-    "tstormn.png": "4n",
-    "tstormsw.png": "4d",
-    "tstormswn.png": "4n",
-    "tstormw.png": "4d",
-    "tstormwn.png": "4n",
-    "wind.png": "24d",
-    "wintrymix.png": "7d",
-    "wintrymixn.png": "7n"
-  };
-    
+  // Icon per weather condition returned by the proxy, as [day, night] codes.
   var conditionMap = {
-    "chanceflurries": "42d",
-    "chancerain": "40d",
-    "chancesleet": "18d",
-    "chancesnow": "42d",
-    "chancetstorms": "38d",
-    "clear": "32d",
-    "cloudy": "26d",
-    "flurries": "13d",
-    "fog": "20d",
-    "hazy": "21d",
-    "mostlycloudy": "28d",
-    "mostlysunny": "29d",
-    "partlycloudy": "30d",
-    "partlysunny": "28d",
-    "sleet": "18d",
-    "rain": "11d",
-    "snow": "16d",
-    "sunny": "32d",
-    "tstorms": "4d",
-    "nt_chanceflurries": "42n",
-    "nt_chancerain": "40n",
-    "nt_chancesleet": "18n",
-    "nt_chancesnow": "42n",
-    "nt_chancetstorms": "38n",
-    "nt_clear": "32n",
-    "nt_cloudy": "26n",
-    "nt_flurries": "13n",
-    "nt_fog": "20n",
-    "nt_hazy": "21n",
-    "nt_mostlycloudy": "28n",
-    "nt_mostlysunny": "29n",
-    "nt_partlycloudy": "30n",
-    "nt_partlysunny": "28n",
-    "nt_sleet": "18n",
-    "nt_rain": "11n",
-    "nt_snow": "16n",
-    "nt_sunny": "32n",
-    "nt_tstorms": "4n"
+    "clear": ["32d", "32n"],
+    "partly-cloudy": ["29d", "29n"],
+    "cloudy": ["26d", "26n"],
+    "fog": ["20d", "20n"],
+    "drizzle": ["9d", "9n"],
+    "freezing-rain": ["10d", "10n"],
+    "rain": ["11d", "11n"],
+    "showers": ["11d", "11n"],
+    "snow": ["16d", "16n"],
+    "thunderstorm": ["4d", "4n"],
+    "unknown": ["32d", "32n"]
   };
-  
+
+  function getIconCode(condition, isDay) {
+    var pair = conditionMap[condition] || conditionMap["unknown"];
+    return isDay === false ? pair[1] : pair[0];
+  }
+
+  var WEATHER_API = 'https://proxy-svc.reveldigital.app/weather';
+
+  // The proxy is always asked for US units and Celsius is derived here, so devices on
+  // either unit preference share a single cached upstream response.
+  function toC(f) {
+    return f == null ? null : (f - 32) * 5 / 9;
+  }
+
+  function resolveLocation(location) {
+    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
+      return "Fargo, ND";
+    }
+    return location;
+  }
+
+  function adaptCurrent(current) {
+    return {
+      icon: current.weather.icon,
+      isDay: current.isDay,
+      weather: current.weather.label,
+      tempF: current.temp,
+      tempC: toC(current.temp)
+    };
+  }
+
+  function adaptDay(day) {
+    return {
+      icon: day.weather.icon,
+      isDay: true,
+      weather: day.weather.label,
+      maxTempF: day.high,
+      minTempF: day.low,
+      maxTempC: toC(day.high),
+      minTempC: toC(day.low)
+    };
+  }
+
   Handlebars.registerHelper('getIcon', function (icon) {
-      return conditionMap_aeris[icon];
+      return getIconCode(icon, this.isDay);
   });
   Handlebars.registerHelper('round', function (num) {
       return parseInt(num);
@@ -443,60 +335,34 @@
       }
     });
     
-    getConditions(search);
-    getForecast(search);
-    
+    getWeather(search);
+
     if (prefs.getString("TileColor") != "") {
       $(".box").css("box-shadow", "0 4px 4px rgba(0,0,0,0.5)");
     }
-    
+
     setInterval(function() {
-      getConditions(search);
-      getForecast(search);
+      getWeather(search);
     }, 1000 * 60 * 30);
   }
-  
-  function getConditions(location) {
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    var api = 'https://api.aerisapi.com/observations/' + encodeURIComponent(location) + '?client_id=hUqX7OlM6GSNFSm9wyhPF&client_secret=dkklytjvrU9sVSfMsNwF6rTiFk8VObvUkwlhPgrW';
+
+  // Current conditions and the forecast arrive in one response, so this is a single call.
+  function getWeather(location) {
     $.ajax({
       type: 'GET',
-      url: api,
+      url: WEATHER_API,
+      data: { q: resolveLocation(location), units: 'us', days: 2 },
       dataType: 'json',
       success: function(data) {
-        if (data.success === false) {
+        if (!data || !data.current || !data.forecast || data.forecast.length < 2) {
           return;
         }
-        $("#current .content").html(currentTemplate(data.response.ob));
+        $("#current .content").html(currentTemplate(adaptCurrent(data.current)));
+        $("#today .content").html(forecastTemplate(adaptDay(data.forecast[0])));
+        $("#tomorrow .content").html(forecastTemplate(adaptDay(data.forecast[1])));
 
         setTimeout(function () {
-          $("#current img").addClass("visible");
-        }, 1000);
-      }
-    });
-  }
-
-  function getForecast(location) {
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    var api = 'https://api.aerisapi.com/forecasts/' + encodeURIComponent(location) + '?client_id=hUqX7OlM6GSNFSm9wyhPF&client_secret=dkklytjvrU9sVSfMsNwF6rTiFk8VObvUkwlhPgrW';
-    $.ajax({
-      type: 'GET',
-      url: api,
-      dataType: 'json',
-      success: function(data) {
-        if (data.success === false) {
-          return;
-        }
-        $("#today .content").html(forecastTemplate(data.response[0].periods[0]));
-        $("#tomorrow .content").html(forecastTemplate(data.response[0].periods[1]));
-
-        setTimeout(function () {
-            $("#today img").addClass("visible");
-            $("#tomorrow img").addClass("visible");
+          $("#current img, #today img, #tomorrow img").addClass("visible");
         }, 1000);
       }
     });

--- a/weather-mini.xml
+++ b/weather-mini.xml
@@ -89,173 +89,55 @@
   var search = prefs.getString("location");
   var unit = prefs.getString("units");
   
-  var conditionMap_aeris = {
-    "am_pcloudyr.png": "cloud-rain-sun",
-    "am_showers.png": "cloud-rain",
-    "am_showshowers.png": "cloud-snow",
-    "am_tstorm.png": "cloud-lightning",
-    "blizzard.png": "snow",
-    "blizzardn.png": "snow",
-    "blowingsnow.png": "snow",
-    "blowingsnown.png": "snow",
-    "chancetstorm.png": "cloud-lightning-sun-2",
-    "chancetstormn.png": "cloud-lightning-moon",
-    "clear.png": "sun",
-    "clearn.png": "moon-50",
-    "clearw.png": "sun",
-    "clearwn.png": "moon-50",
-    "cloudy.png": "clouds",
-    "cloudyn.png": "clouds",
-    "cloudyw.png": "clouds",
-    "cloudywn.png": "clouds",
-    "drizzle.png": "clouds",
-    "drizzlef.png": "clouds",
-    "drizzlen.png": "clouds",
-    "dust.png": "fog",
-    "fair.png": "sun",
-    "fairn.png": "moon-50",
-    "fairw.png": "sun",
-    "fairwn.png": "moon-50",
-    "fdrizzle.png": "drizzle",
-    "fdrizzlen.png": "drizzle",
-    "flurries.png": "cloud-snow-sun",
-    "flurriesn.png": "cloud-snow-moon",
-    "flurriesw.png": "cloud-snow-sun",
-    "flurrieswn.png": "cloud-snow-moon",
-    "fog.png": "fog",
-    "fogn.png": "fog",
-    "freezingrain.png": "rain",
-    "freezingrainn.png": "rain",
-    "hazy.png": "fog",
-    "hazyn.png": "fog",
-    "mcloudy.png": "clouds-sun",
-    "mcloudyn.png": "clouds-moon",
-    "mcloudyr.png": "cloud-rain-sun",
-    "mcloudyrn.png": "cloud-rain-moon",
-    "mcloudyrw.png": "cloud-wind-sun",
-    "mcloudyrwn.png": "cloud-wind-moon",
-    "mcloudys.png": "cloud-snow-sun",
-    "mcloudysfn.png": "cloud-snow-moon",
-    "mcloudysfw.png": "cloud-snow-sun",
-    "mcloudysfwn.png": "cloud-snow-moon",
-    "mcloudysn.png": "cloud-snow-moon",
-    "mcloudysw.png": "cloud-snow-sun",
-    "mcloudyswn.png": "cloud-snow-moon",
-    "mcloudyt.png": "cloud-rain-lightning-sun",
-    "mcloudytn.png": "cloud-rain-lightning-moon",
-    "mcloudytw.png": "cloud-rain-lightning-sun",
-    "mcloudytwn.png": "cloud-rain-lightning-moon",
-    "mcloudyw.png": "cloud-wind-2",
-    "mcloudywn.png": "cloud-wind-2-moon",
-    "na.png": "",
-    "pcloudy.png": "clouds-sun",
-    "pcloudyn.png": "clouds-moon",
-    "pcloudyr.png": "cloud-rain-sun",
-    "pcloudyrn.png": "cloud-rain-moon",
-    "pcloudyrw.png": "cloud-wind-sun",
-    "pcloudyrwn.png": "cloud-wind-moon",
-    "pcloudys.png": "cloud-snow-sun",
-    "pcloudysf.png": "cloud-snow-sun",
-    "pcloudysfn.png": "cloud-snow-moon",
-    "pcloudysfw.png": "cloud-snow-sun",
-    "pcloudysfwn.png": "cloud-snow-moon",
-    "pcloudysn.png": "cloud-snow-moon",
-    "pcloudysw.png": "cloud-rain-sun",
-    "pcloudyswn.png": "cloud-snow-moon",
-    "pcloudyt.png": "cloud-rain-lightning-sun",
-    "pcloudytn.png": "cloud-rain-lightning-moon",
-    "pcloudytw.png": "cloud-rain-lightning-sun",
-    "pcloudytwn.png": "cloud-rain-lightning-moon",
-    "pcloudyw.png": "cloud-wind-2",
-    "pcloudywn.png": "cloud-wind-2-moon",
-    "pm_pcloudy.png": "clouds-sun",
-    "pm_pcloudyr.png": "cloud-rain-sun",
-    "pm_showers.png": "rain",
-    "pm_snowshowers.png": "snow",
-    "pm_tstorm.png": "lightning",
-    "rain.png": "rain",
-    "rainandsnow.png": "hail",
-    "rainandsnown.png": "hail",
-    "rainn.png": "rain",
-    "raintosnow.png": "rain",
-    "raintosnown.png": "rain",
-    "rainw.png": "rain",
-    "showers.png": "rain",
-    "showersn.png": "rain",
-    "showersw.png": "rain",
-    "sleet.png": "drizzle",
-    "sleetn.png": "drizzle",
-    "sleetsnow.png": "drizzle",
-    "smoke.png": "fog",
-    "smoken.png": "fog",
-    "snow.png": "snow",
-    "snown.png": "snow",
-    "snowshowers.png": "snow",	
-    "snowshowersn.png": "snow",
-    "snowshowersw.png": "snow",
-    "snowshowerswn.png": "snow",
-    "snowtorain.png": "snow",
-    "snowtorainn.png": "snow",
-    "snoww.png": "snow",
-    "snowwn.png": "snow",
-    "sunny.png": "sun",
-    "sunnyn.png": "sun",
-    "sunnyw.png": "sun",
-    "sunnywn.png": "sun",
-    "tstorm.png": "lightning",
-    "tstormn.png": "lightning",
-    "tstormsw.png": "lightning",
-    "tstormswn.png": "lightning",
-    "tstormw.png": "lightning",
-    "tstormwn.png": "lightning",
-    "wind.png": "wind",
-    "wintrymix.png": "drizzle",
-    "wintrymixn.png": "drizzle"
-  };
-  
+  // Icon per weather condition returned by the proxy, as [day, night] classes.
   var conditionMap = {
-    "chanceflurries": "diw-cloud-snow-sun",
-    "chancerain": "diw-cloud-rain-sun",
-    "chancesleet": "diw-cloud-drizzle-sun",
-    "chancesnow": "diw-cloud-snow-sun",
-    "chancetstorms": "diw-cloud-lightning-sun",
-    "clear": "diw-sun",
-    "cloudy": "diw-cloud",
-    "flurries": "diw-snow",
-    "fog": "diw-fog",
-    "hazy": "diw-cloud-fog-sun",
-    "mostlycloudy": "diw-clouds-sun",
-    "mostlysunny": "diw-clouds-sun",
-    "partlycloudy": "diw-clouds-sun",
-    "partlysunny": "diw-clouds-sun",
-    "sleet": "diw-drizzle",
-    "rain": "diw-rain",
-    "snow": "diw-snow",
-    "sunny": "diw-sun",
-    "tstorms": "diw-lightning",
-    "nt_chanceflurries": "diw-cloud-snow-moon",
-    "nt_chancerain": "diw-cloud-rain-moon",
-    "nt_chancesleet": "diw-cloud-drizzle-moon",
-    "nt_chancesnow": "diw-cloud-snow-moon",
-    "nt_chancetstorms": "diw-cloud-lightning-moon",
-    "nt_clear": "diw-moon",
-    "nt_cloudy": "diw-cloud",
-    "nt_flurries": "diw-snow",
-    "nt_fog": "diw-fog",
-    "nt_hazy": "diw-cloud-fog-moon",
-    "nt_mostlycloudy": "diw-clouds-moon",
-    "nt_mostlysunny": "diw-clouds-moon",
-    "nt_partlycloudy": "diw-clouds-moon",
-    "nt_partlysunny": "diw-clouds-moon",
-    "nt_sleet": "diw-drizzle",
-    "nt_rain": "diw-rain",
-    "nt_snow": "diw-snow",
-    "nt_sunny": "diw-moon",
-    "nt_tstorms": "diw-lightning"
+    "clear": ["sun", "moon-50"],
+    "partly-cloudy": ["clouds-sun", "clouds-moon"],
+    "cloudy": ["clouds", "clouds-moon"],
+    "fog": ["fog", "fog"],
+    "drizzle": ["drizzle", "drizzle"],
+    "freezing-rain": ["hail", "hail"],
+    "rain": ["rain", "cloud-rain-moon"],
+    "showers": ["cloud-rain-sun", "cloud-rain-moon"],
+    "snow": ["snow", "cloud-snow-moon"],
+    "thunderstorm": ["lightning", "cloud-lightning-moon"],
+    "unknown": ["sun", "moon-50"]
   };
 
+  function getIconCode(condition, isDay) {
+    var pair = conditionMap[condition] || conditionMap["unknown"];
+    return isDay === false ? pair[1] : pair[0];
+  }
+
+  var WEATHER_API = 'https://proxy-svc.reveldigital.app/weather';
+
+  // The proxy is always asked for US units and Celsius is derived here, so devices on
+  // either unit preference share a single cached upstream response.
+  function toC(f) {
+    return f == null ? null : (f - 32) * 5 / 9;
+  }
+
+  function resolveLocation(location) {
+    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
+      return "Fargo, ND";
+    }
+    return location;
+  }
+
+  function adaptDay(day) {
+    return {
+      icon: day.weather.icon,
+      isDay: true,
+      weather: day.weather.label,
+      maxTempF: day.high,
+      minTempF: day.low,
+      maxTempC: toC(day.high),
+      minTempC: toC(day.low)
+    };
+  }
+
   Handlebars.registerHelper('getIcon', function (icon) {
-      return conditionMap_aeris[icon];
+      return getIconCode(icon, this.isDay);
   });
   Handlebars.registerHelper('round', function (num) {
       return parseInt(num);
@@ -282,20 +164,16 @@
   }
 
   function getForecast(location) {
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    
-    var api = 'https://proxy-svc.reveldigital.app/weather/forecasts/' + encodeURIComponent(location) + '?a=1';
     $.ajax({
       type: 'GET',
-      url: api,
+      url: WEATHER_API,
+      data: { q: resolveLocation(location), units: 'us', days: 1 },
       dataType: 'json',
       success: function(data) {
-        if (data.success === false) {
+        if (!data || !data.forecast || !data.forecast.length) {
           return;
         }
-        $("#container").html(currentTemplate(data.response[0].periods[0]));
+        $("#container").html(currentTemplate(adaptDay(data.forecast[0])));
       }
     });
   }

--- a/weather-v2.xml
+++ b/weather-v2.xml
@@ -198,34 +198,51 @@ div, span
   if (prefs.getString("Units") == 'si'){
     metricU = true;}
   
-  function mapIcon(icon) {
-  
-    switch (icon) {
+  var WEATHER_API = 'https://proxy-svc.reveldigital.app/weather';
+
+  // The proxy is always asked for US units and metric is derived here, so devices on
+  // either unit preference share a single cached upstream response.
+  function toC(f) {
+    return f == null ? null : (f - 32) * 5 / 9;
+  }
+
+  function toKPH(mph) {
+    return mph == null ? null : mph * 1.609344;
+  }
+
+  function resolveLocation(location) {
+    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
+      return "Fargo, ND";
+    }
+    return location;
+  }
+
+  // Skycons has no thunderstorm animation, so storms fall back to rain.
+  function mapIcon(condition, isDay) {
+
+    switch (condition) {
       case 'clear':
-        return Skycons.CLEAR_DAY;
-      case 'clearn':
-        return Skycons.CLEAR_NIGHT;
-      case 'pcloudyn':
-        return Skycons.PARTLY_CLOUDY_NIGHT;
-      case 'pcloudy':
-        return Skycons.PARTLY_CLOUDY_DAY;
+        return isDay === false ? Skycons.CLEAR_NIGHT : Skycons.CLEAR_DAY;
+      case 'partly-cloudy':
+        return isDay === false ? Skycons.PARTLY_CLOUDY_NIGHT : Skycons.PARTLY_CLOUDY_DAY;
       case 'cloudy':
         return Skycons.CLOUDY;
+      case 'drizzle':
       case 'rain':
+      case 'showers':
+      case 'thunderstorm':
         return Skycons.RAIN;
-      case 'sleet':
+      case 'freezing-rain':
         return Skycons.SLEET;
       case 'snow':
         return Skycons.SNOW;
-      case 'wind':
-        return Skycons.WIND;
       case 'fog':
         return Skycons.FOG;
       default:
-        return Skycons.CLEAR_DAY;
+        return isDay === false ? Skycons.CLEAR_NIGHT : Skycons.CLEAR_DAY;
     }
   }
-  
+
   function load() {
     
     WebFont.load({
@@ -241,90 +258,75 @@ div, span
       "resizeClear": true
     });
     
-    getConditions(search);
-    getForecast(search);
-    
+    getWeather(search);
+
     setInterval(function() {
-      getConditions(search);
-      getForecast(search);
+      getWeather(search);
     }, 1000 * 60 * 30);
   }
 
-   function getConditions(location) {
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    var api = 'https://api.aerisapi.com/observations/' + encodeURIComponent(location) + '?client_id=hUqX7OlM6GSNFSm9wyhPF&client_secret=dkklytjvrU9sVSfMsNwF6rTiFk8VObvUkwlhPgrW';
+  // Current conditions and the forecast arrive in one response, so this is a single call.
+  function getWeather(location) {
     $.ajax({
       type: 'GET',
-      url: api,
+      url: WEATHER_API,
+      data: {
+        q: resolveLocation(location),
+        units: 'us',
+        days: prefs.getInt("ForecastDays")
+      },
       dataType: 'json',
       success: function(data) {
-        if (data.success === false) {
+        if (!data || !data.current || !data.forecast) {
           return;
         }
-        skycons.remove("fe_current_icon");
-        skycons.add("fe_current_icon", mapIcon((data.response.ob.icon).split('.').slice(0, -1).join('.')));
-        $(".fe_summary").text(data.response.ob.weatherShort);
-        if (metricU) {
-          $(".fe_wind").text("Wind: " + parseInt(data.response.ob.windSpeedKPH) + " kph");
-          $(".fe_temp").text(parseInt(data.response.ob.tempC));}
-        else {
-          $(".fe_wind").text("Wind: " + parseInt(data.response.ob.windSpeedMPH) + " mph");
-          $(".fe_temp").text(parseInt(data.response.ob.tempF));}
+        renderCurrent(data.current);
+        renderForecast(data.forecast);
       }
     });
   }
 
-  function getForecast(location) {
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    var api = 'https://api.aerisapi.com/forecasts/' + encodeURIComponent(location) + '?client_id=hUqX7OlM6GSNFSm9wyhPF&client_secret=dkklytjvrU9sVSfMsNwF6rTiFk8VObvUkwlhPgrW';
-    $.ajax({
-      type: 'GET',
-      url: api,
-      dataType: 'json',
-      success: function(data) {
-        if (data.success === false) {
-          return;
-        }
-        $('.fe_daily').empty();
-      
-        if (metricU){
-          var max = data.response[0].periods[0].maxTempC;
-          var min = data.response[0].periods[0].minTempC;}
-        else {
-          var max = data.response[0].periods[0].maxTempF;
-          var min = data.response[0].periods[0].minTempF;}
+  function renderCurrent(current) {
+    skycons.remove("fe_current_icon");
+    skycons.add("fe_current_icon", mapIcon(current.weather.icon, current.isDay));
+    $(".fe_summary").text(current.weather.label);
 
-        for (let i = 0; i < prefs.getInt("ForecastDays"); i++) {
-            var t = new Date(1970,0,1);
-            t.setSeconds(data.response[0].periods[i].timestamp);
-            
-            var fe_day = $("<div class='fe_day'></div>");
-            var fe_label = $("<span class='fe_label'></span>");
-            var fe_icon = $("<canvas class='fe_icon' width='70' height='70' id='fe_day_icon" + i + "'></canvas>");
-            var fe_temp_bar = $("<div class='fe_temp_bar'></div>");
-            var fe_high_temp = $("<span class='fe_high_temp'></span>");
-            var fe_low_temp = $("<span class='fe_low_temp'></span>");
-            fe_temp_bar.append(fe_high_temp).append(fe_low_temp);
-            fe_day.append(fe_label).append(fe_icon).append(fe_temp_bar);
-            $(".fe_daily").append(fe_day);
-            
-            skycons.add('fe_day_icon' + i, mapIcon((data.response[0].periods[i].icon).split('.').slice(0, -1).join('.')));
-            if (metricU) {
-              $(fe_high_temp).text(parseInt(data.response[0].periods[i].maxTempC));
-              $(fe_low_temp).text(parseInt(data.response[0].periods[i].minTempC));
-              $(fe_label).text(days[t.getDay()]);
-              $(fe_temp_bar).css('height', (data.response[0].periods[i].maxTempC - data.response[0].periods[i].minTempC) * 3 + 'px');}
-            else {
-              $(fe_high_temp).text(parseInt(data.response[0].periods[i].maxTempF));
-              $(fe_low_temp).text(parseInt(data.response[0].periods[i].minTempF));
-              $(fe_label).text(days[t.getDay()]);
-              $(fe_temp_bar).css('height', (data.response[0].periods[i].maxTempF - data.response[0].periods[i].minTempF) * 3 + 'px');}
-        }}
-    });
+    if (metricU) {
+      $(".fe_wind").text("Wind: " + parseInt(toKPH(current.windSpeed)) + " kph");
+      $(".fe_temp").text(parseInt(toC(current.temp)));}
+    else {
+      $(".fe_wind").text("Wind: " + parseInt(current.windSpeed) + " mph");
+      $(".fe_temp").text(parseInt(current.temp));}
+  }
+
+  function renderForecast(forecast) {
+    $('.fe_daily').empty();
+
+    for (let i = 0; i < forecast.length; i++) {
+        var day = forecast[i];
+        // The date is a plain YYYY-MM-DD; anchoring it at midnight local time keeps
+        // the weekday from slipping a day in timezones behind UTC.
+        var t = new Date(day.date + "T00:00:00");
+
+        var high = metricU ? toC(day.high) : day.high;
+        var low = metricU ? toC(day.low) : day.low;
+
+        var fe_day = $("<div class='fe_day'></div>");
+        var fe_label = $("<span class='fe_label'></span>");
+        var fe_icon = $("<canvas class='fe_icon' width='70' height='70' id='fe_day_icon" + i + "'></canvas>");
+        var fe_temp_bar = $("<div class='fe_temp_bar'></div>");
+        var fe_high_temp = $("<span class='fe_high_temp'></span>");
+        var fe_low_temp = $("<span class='fe_low_temp'></span>");
+        fe_temp_bar.append(fe_high_temp).append(fe_low_temp);
+        fe_day.append(fe_label).append(fe_icon).append(fe_temp_bar);
+        $(".fe_daily").append(fe_day);
+
+        skycons.add('fe_day_icon' + i, mapIcon(day.weather.icon, true));
+        $(fe_high_temp).text(parseInt(high));
+        $(fe_low_temp).text(parseInt(low));
+        $(fe_label).text(days[t.getDay()]);
+        $(fe_temp_bar).css('height', (high - low) * 3 + 'px');
+    }
   }
 
   gadgets.util.registerOnLoadHandler(load);

--- a/weather.xml
+++ b/weather.xml
@@ -259,173 +259,65 @@
   var search = prefs.getString("Location");
   var unit = prefs.getString("Units");
   
-  var conditionMap_aeris = {
-    "am_pcloudyr.png": "40d",
-    "am_showers.png": "40d",
-    "am_showshowers.png": "46d",
-    "am_tstorm.png": "4d",
-    "blizzard.png": "46d",
-    "blizzardn.png": "46n",
-    "blowingsnow.png": "42d",
-    "blowingsnown.png": "42n",
-    "chancetstorm.png": "38d",
-    "chancetstormn.png": "38n",
-    "clear.png": "32d",
-    "clearn.png": "32n",
-    "clearw.png": "32d",
-    "clearwn.png": "32n",
-    "cloudy.png": "26d",
-    "cloudyn.png": "26n",
-    "cloudyw.png": "26d",
-    "cloudywn.png": "26n",
-    "drizzle.png": "9d",
-    "drizzlef.png": "9d",
-    "drizzlen.png": "9n",
-    "dust.png": "19d",
-    "fair.png": "33d",
-    "fairn.png": "33n",
-    "fairw.png": "33d",
-    "fairwn.png": "33n",
-    "fdrizzle.png": "8d",
-    "fdrizzlen.png": "8n",
-    "flurries.png": "13d",
-    "flurriesn.png": "13n",
-    "flurriesw.png": "13d",
-    "flurrieswn.png": "13n",
-    "fog.png": "20d",
-    "fogn.png": "20n",
-    "freezingrain.png": "10d",
-    "freezingrainn.png": "10n",
-    "hazy.png": "21d",
-    "hazyn.png": "21n",
-    "mcloudy.png": "27d",
-    "mcloudyn.png": "27n",
-    "mcloudyr.png": "27d",
-    "mcloudyrn.png": "27n",
-    "mcloudyrw.png": "27d",
-    "mcloudyrwn.png": "27n",
-    "mcloudys.png": "27d",
-    "mcloudysfn.png": "27n",
-    "mcloudysfw.png": "27d",
-    "mcloudysfwn.png": "27n",
-    "mcloudysn.png": "27d",
-    "mcloudysw.png": "27d",
-    "mcloudyswn.png": "27n",
-    "mcloudyt.png": "27d",
-    "mcloudytn.png": "27n",
-    "mcloudytw.png": "27d",
-    "mcloudytwn.png": "27n",
-    "mcloudyw.png": "27d",
-    "mcloudywn.png": "27n",
-    "na.png": "",
-    "pcloudy.png": "29d",
-    "pcloudyn.png": "29n",
-    "pcloudyr.png": "29d",
-    "pcloudyrn.png": "29n",
-    "pcloudyrw.png": "29d",
-    "pcloudyrwn.png": "29n",
-    "pcloudys.png": "29d",
-    "pcloudysf.png": "29d",
-    "pcloudysfn.png": "29n",
-    "pcloudysfw.png": "29d",
-    "pcloudysfwn.png": "29n",
-    "pcloudysn.png": "29n",
-    "pcloudysw.png": "29d",
-    "pcloudyswn.png": "29n",
-    "pcloudyt.png": "29d",
-    "pcloudytn.png": "29n",
-    "pcloudytw.png": "29d",
-    "pcloudytwn.png": "29n",
-    "pcloudyw.png": "29d",
-    "pcloudywn.png": "29n",
-    "pm_pcloudy.png": "29d",
-    "pm_pcloudyr.png": "29d",
-    "pm_showers.png": "12d",
-    "pm_snowshowers.png": "46d",
-    "pm_tstorm.png": "4d",
-    "rain.png": "11d",
-    "rainandsnow.png": "5d",
-    "rainandsnown.png": "5n",
-    "rainn.png": "11n",
-    "raintosnow.png": "5d",
-    "raintosnown.png": "5n",
-    "rainw.png": "11d",
-    "showers.png": "11d",
-    "showersn.png": "11n",
-    "showersw.png": "11d",
-    "sleet.png": "18d",
-    "sleetn.png": "18n",
-    "sleetsnow.png": "7d",
-    "smoke.png": "22d",
-    "smoken.png": "22n",
-    "snow.png": "16d",
-    "snown.png": "16n",
-    "snowshowers.png": "46d",	
-    "snowshowersn.png": "46n",
-    "snowshowersw.png": "46d",
-    "snowshowerswn.png": "46n",
-    "snowtorain.png": "5d",
-    "snowtorainn.png": "5n",
-    "snoww.png": "16d",
-    "snowwn.png": "16n",
-    "sunny.png": "32d",
-    "sunnyn.png": "32n",
-    "sunnyw.png": "32d",
-    "sunnywn.png": "32n",
-    "tstorm.png": "4d",
-    "tstormn.png": "4n",
-    "tstormsw.png": "4d",
-    "tstormswn.png": "4n",
-    "tstormw.png": "4d",
-    "tstormwn.png": "4n",
-    "wind.png": "24d",
-    "wintrymix.png": "7d",
-    "wintrymixn.png": "7n"
-  };
-  
+  // Icon per weather condition returned by the proxy, as [day, night] codes.
   var conditionMap = {
-    "chanceflurries": "42d",
-    "chancerain": "40d",
-    "chancesleet": "18d",
-    "chancesnow": "42d",
-    "chancetstorms": "38d",
-    "clear": "32d",
-    "cloudy": "26d",
-    "flurries": "13d",
-    "fog": "20d",
-    "hazy": "21d",
-    "mostlycloudy": "28d",
-    "mostlysunny": "29d",
-    "partlycloudy": "30d",
-    "partlysunny": "28d",
-    "sleet": "18d",
-    "rain": "11d",
-    "snow": "16d",
-    "sunny": "32d",
-    "tstorms": "4d",
-    "nt_chanceflurries": "42n",
-    "nt_chancerain": "40n",
-    "nt_chancesleet": "18n",
-    "nt_chancesnow": "42n",
-    "nt_chancetstorms": "38n",
-    "nt_clear": "32n",
-    "nt_cloudy": "26n",
-    "nt_flurries": "13n",
-    "nt_fog": "20n",
-    "nt_hazy": "21n",
-    "nt_mostlycloudy": "28n",
-    "nt_mostlysunny": "29n",
-    "nt_partlycloudy": "30n",
-    "nt_partlysunny": "28n",
-    "nt_sleet": "18n",
-    "nt_rain": "11n",
-    "nt_snow": "16n",
-    "nt_sunny": "32n",
-    "nt_tstorms": "4n"
+    "clear": ["32d", "32n"],
+    "partly-cloudy": ["29d", "29n"],
+    "cloudy": ["26d", "26n"],
+    "fog": ["20d", "20n"],
+    "drizzle": ["9d", "9n"],
+    "freezing-rain": ["10d", "10n"],
+    "rain": ["11d", "11n"],
+    "showers": ["11d", "11n"],
+    "snow": ["16d", "16n"],
+    "thunderstorm": ["4d", "4n"],
+    "unknown": ["32d", "32n"]
   };
 
+  function getIconCode(condition, isDay) {
+    var pair = conditionMap[condition] || conditionMap["unknown"];
+    return isDay === false ? pair[1] : pair[0];
+  }
+
+  var WEATHER_API = 'https://proxy-svc.reveldigital.app/weather';
+
+  // The proxy is always asked for US units and Celsius is derived here, so devices on
+  // either unit preference share a single cached upstream response.
+  function toC(f) {
+    return f == null ? null : (f - 32) * 5 / 9;
+  }
+
+  function resolveLocation(location) {
+    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
+      return "Fargo, ND";
+    }
+    return location;
+  }
+
+  function adaptCurrent(current) {
+    return {
+      icon: current.weather.icon,
+      isDay: current.isDay,
+      weather: current.weather.label,
+      tempF: current.temp,
+      tempC: toC(current.temp)
+    };
+  }
+
+  function adaptDay(day) {
+    return {
+      icon: day.weather.icon,
+      isDay: true,
+      weather: day.weather.label,
+      maxTempF: day.high,
+      minTempF: day.low,
+      maxTempC: toC(day.high),
+      minTempC: toC(day.low)
+    };
+  }
+
   Handlebars.registerHelper('getIcon', function (icon) {
-      return conditionMap_aeris[icon];
+      return getIconCode(icon, this.isDay);
   });
   Handlebars.registerHelper('round', function (num) {
       return parseInt(num);
@@ -445,60 +337,34 @@
       }
     });
     
-    getConditions(search);
-    getForecast(search);
-    
+    getWeather(search);
+
     if (prefs.getString("TileColor") != "") {
       $(".box").css("box-shadow", "0 4px 4px rgba(0,0,0,0.5)");
     }
-    
+
     setInterval(function() {
-      getConditions(search);
-      getForecast(search);
+      getWeather(search);
     }, 1000 * 60 * 30);
   }
-  
-  function getConditions(location) {
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    var api = 'https://api.aerisapi.com/observations/' + encodeURIComponent(location) + '?client_id=hUqX7OlM6GSNFSm9wyhPF&client_secret=dkklytjvrU9sVSfMsNwF6rTiFk8VObvUkwlhPgrW';
+
+  // Current conditions and the forecast arrive in one response, so this is a single call.
+  function getWeather(location) {
     $.ajax({
       type: 'GET',
-      url: api,
+      url: WEATHER_API,
+      data: { q: resolveLocation(location), units: 'us', days: 2 },
       dataType: 'json',
       success: function(data) {
-        if (data.success === false) {
+        if (!data || !data.current || !data.forecast || data.forecast.length < 2) {
           return;
         }
-        $("#current .content").html(currentTemplate(data.response.ob));
+        $("#current .content").html(currentTemplate(adaptCurrent(data.current)));
+        $("#today .content").html(forecastTemplate(adaptDay(data.forecast[0])));
+        $("#tomorrow .content").html(forecastTemplate(adaptDay(data.forecast[1])));
 
         setTimeout(function () {
-          $("#current img").addClass("visible");
-        }, 1000);
-      }
-    });
-  }
-
-  function getForecast(location) {
-    if (location == "" || location.indexOf("*|DEVICE.LOCATION.CITY|*") != -1) {
-      location = "Fargo, ND";
-    }
-    var api = 'https://api.aerisapi.com/forecasts/' + encodeURIComponent(location) + '?client_id=hUqX7OlM6GSNFSm9wyhPF&client_secret=dkklytjvrU9sVSfMsNwF6rTiFk8VObvUkwlhPgrW';
-    $.ajax({
-      type: 'GET',
-      url: api,
-      dataType: 'json',
-      success: function(data) {
-        if (data.success === false) {
-          return;
-        }
-        $("#today .content").html(forecastTemplate(data.response[0].periods[0]));
-        $("#tomorrow .content").html(forecastTemplate(data.response[0].periods[1]));
-
-        setTimeout(function () {
-          $("#today img").addClass("visible");
-          $("#tomorrow img").addClass("visible");
+          $("#current img, #today img, #tomorrow img").addClass("visible");
         }, 1000);
       }
     });


### PR DESCRIPTION
Replace the old Aeris observation/forecast calls with the consolidated weather proxy across all weather gadgets. The templates now adapt the proxy's current and forecast payloads, use simplified day/night icon mappings, and derive Celsius and kph locally from a shared US-units response to improve cache reuse and keep current conditions plus forecast in sync.